### PR TITLE
Add a check for line while reading the lines to install last package without new-line

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -67,7 +67,8 @@ else
 	# Ignore stderr from apt-get update containing: rm: cannot remove '/var/cache/apt/archives/partial/*.deb': Permission denied
 	apt-get "${APT_OPTIONS[@]}" update 2> >(grep -v "rm: cannot remove")
 
-	while read -r line; do
+	# This will read the last line of the Aptfile even with no new-line at the end
+	while read -r line || [ -n "$line" ]; do
 		if [[ $line != "#"* ]] && [[ $line != ":repo:"* ]]; then
 			PACKAGE=$line
 			if [[ $PACKAGE == *deb ]]; then

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "digitalocean/apt"
-version = "0.0.2"
+version = "0.0.3"
 name = "apt Packages Buildpack"
 homepage = "https://github.com/digitalocean/buildpack-apt"
 description = "Installs apt packages for further builds and runtime"

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -53,7 +53,7 @@ assert_file_exists $buildsh
 layer_dir=/e2e/layers
 mkdir /workspace
 cd /workspace || exit 1
-echo tree > Aptfile
+echo -n "tree" > Aptfile
 assert_file_content "Aptfile" "tree"
 
 #################


### PR DESCRIPTION
## Details

The Loop: `while read -r line; do` won't run for the last line if no newline is present in the file.

This PR fixes this by adding a check to see if `$line` is empty.
If new line is not present, `$line` will have the last time otherwise it will be empty