### PR TITLE
APPS-10823: Update Buildpack API to v0.8

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -140,9 +140,12 @@ else
 	echo -n ":" >"$apt_env_dir"/PKG_CONFIG_PATH.delim
 fi
 
-echo "launch = true" >"${apt_layer}".toml
-echo "build = true" >>"${apt_layer}".toml
-echo "cache = true" >>"${apt_layer}".toml
+cat > "${apt_layer}.toml" <<-EOL
+[types]
+launch = true
+build = true
+cache = true
+EOL
 
 end_time=$(date +%s%N)
 log::info "=> Installed $(wc -l Aptfile | cut -d' ' -f1) packages in $(($((end_time - start_time)) / 1000000000))s"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "digitalocean/apt"
-version = "0.1.3"
+version = "0.1.0"
 name = "apt Packages Buildpack"
 homepage = "https://github.com/digitalocean/buildpack-apt"
 description = "Installs apt packages for further builds and runtime"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,8 +1,8 @@
-api = "0.4"
+api = "0.8"
 
 [buildpack]
 id = "digitalocean/apt"
-version = "0.0.3"
+version = "0.1.3"
 name = "apt Packages Buildpack"
 homepage = "https://github.com/digitalocean/buildpack-apt"
 description = "Installs apt packages for further builds and runtime"
@@ -10,9 +10,6 @@ keywords = ["apt", "packages", "ubuntu"]
 
 [[buildpack.licenses]]
 type = "MIT"
-
-[[stacks]]
-id = "heroku-20"
 
 [[stacks]]
 id = "heroku-22"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/buildpack-apt
 
-go 1.19
+go 1.24
 
 require github.com/stretchr/testify v1.7.0
 


### PR DESCRIPTION
## Description:

Update Buildpack API from 0.4 to 0.8.
Buildpack API 0.4 has been deprecated in lifecycle 0.16.0.
So using this buildpack result in deprecation warnings:

eg:

```
===> DETECTING
Warning: Buildpack 'digitalocean/apt@0.0.3' requests deprecated API '0.4'
```